### PR TITLE
Add variable values when coercing existing filter

### DIFF
--- a/__tests__/helpers/interfacesHelper.ts
+++ b/__tests__/helpers/interfacesHelper.ts
@@ -152,6 +152,15 @@ query {
 }
 `;
 
+export const QueryWithFilterVariables = `
+query($testName: String) {
+    Task(filter: { name: $testName }) {
+        name
+        order
+    }
+}
+`;
+
 export const QueryWithFilterArgumentNode = expect.objectContaining({
   kind: 'Argument',
   name: expect.objectContaining({

--- a/__tests__/helpers/runResolvers.ts
+++ b/__tests__/helpers/runResolvers.ts
@@ -9,13 +9,14 @@ export function runTestThroughResolver(
   typeName: string,
   mockReturn: any,
   testFn: (object: any, args: { [argName: string]: any }, ctx: any, resolveInfo: GraphQLResolveInfo) => void,
+  variables: any = {},
 ): Promise<ExecutionResult> {
   const resolvers = resolverShell(typeName, mockReturn, testFn);
   const schema = makeAugmentedSchema({
     resolvers,
     typeDefs,
   });
-  return graphql(schema, query, null, context);
+  return graphql(schema, query, null, context, variables);
 }
 
 export const goodQuery = `

--- a/__tests__/interfaces.test.ts
+++ b/__tests__/interfaces.test.ts
@@ -14,6 +14,7 @@ import {
   BasicFilterArgumentNode,
   BasicAuthFilterParam,
   QueryWithFilter,
+  QueryWithFilterVariables,
   QueryWithFilterArgumentNode,
   QueryWithNestedObject,
   QueryWithFilteredNestedObject,
@@ -96,6 +97,32 @@ describe('Applying deepAuth through Extensions and Interfaces', () => {
         'Task',
         BasicResponse,
         testFn,
+      ).then((response) => {
+        expect(response).toEqual(BasicResponse);
+      });
+    });
+    test('nests an existing filter argument using variables on root selection', () => {
+      const testFn = (object: any, args: { [argName: string]: any }, ctx: any, resolveInfo: GraphQLResolveInfo) => {
+        expect(args).toHaveProperty('filter', BasicExistingFilterParam);
+        const { authParams, authResolveInfo: testTranslate } = applyDeepAuth(args, ctx, resolveInfo);
+        expect(authParams).toHaveProperty('filter', QueryWithFilterParams);
+        expect(testTranslate).toHaveProperty(
+          ['operation', 'selectionSet', 'selections', 0, 'arguments', 0],
+          QueryWithFilterArgumentNode,
+        );
+        // @ts-ignore
+        // tslint:disable-next-line: no-console
+        // console.log(JSON.stringify(testTranslate?.operation?.selectionSet?.selections?.[0]?.arguments?.[0], null, 2));
+      };
+
+      return runTestThroughResolver(
+        ExtensionTypeDefs,
+        QueryWithFilterVariables,
+        BasicContext,
+        'Task',
+        BasicResponse,
+        testFn,
+        { testName: 'Groot' },
       ).then((response) => {
         expect(response).toEqual(BasicResponse);
       });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "neo4j-deepauth",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "neo4j-deepauth",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "Directive-based authorization for neo4j-graphql-js GraphQL endpoints",
   "main": "lib/index.js",
   "files": [

--- a/src/rules/AuthorizationFilterRule.ts
+++ b/src/rules/AuthorizationFilterRule.ts
@@ -54,7 +54,7 @@ export default function AuthorizationFilterRule(
         ancestors: any,
       ) {
         // Check if Field Definition contains a
-        const fieldDef = context.getFieldDef()?.astNode?.directives?.find(dir => dir.name.value === 'deepAuth');
+        const fieldDef = context.getFieldDef()?.astNode?.directives?.find((dir) => dir.name.value === 'deepAuth');
         const fieldAuthConfig =
           fieldDef && fieldDef.arguments?.reduce(deepAuthArgumentReducer, { path: '', variables: [], filterInput: '' });
         const [fieldAuthFilter, fieldFilterInputType] = fieldAuthConfig
@@ -91,7 +91,11 @@ export default function AuthorizationFilterRule(
                 name: { kind: 'Name', value: 'filter' },
                 // `value` must be type ValueNode.
                 value: astFromValue(
-                  coerceDeepAuthInputValue(valueFromASTUntyped(existingFilter.value), filterInputType, context),
+                  coerceDeepAuthInputValue(
+                    valueFromASTUntyped(existingFilter.value, context.getVariableValues()),
+                    filterInputType,
+                    context,
+                  ),
                   filterInputType,
                 ),
               },


### PR DESCRIPTION
Bugfix: GraphQL variables in an original query used within a filter argument will now propagate into the modified filter argument.